### PR TITLE
fix php header to activate php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 ob_start("ob_gzhandler");
 header("Content-Encoding: gzip");
 session_start();


### PR DESCRIPTION
apache seems to require the php in <?php to run as php

(first pull request - hopefully did it correctly)